### PR TITLE
Set definable color value or default to first swatch

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,5 +1,5 @@
 import { Flex, ChakraProvider, theme } from "@chakra-ui/react";
-import React, { useState } from "react";
+import React from "react";
 import { ColorPicker } from "../../";
 
 export const App = () => {
@@ -7,7 +7,7 @@ export const App = () => {
     <ChakraProvider theme={theme}>
       <Flex w="full" h="100vh">
         <Flex flex={1} justify="center" align="center" background="blue.900">
-          <ColorPicker onChange={(color) => console.log(color)} />
+          <ColorPicker onChange={(color) => console.log(color)} defaultColor="orange.500" />
         </Flex>
       </Flex>
     </ChakraProvider>

--- a/src/colorPicker.tsx
+++ b/src/colorPicker.tsx
@@ -26,13 +26,14 @@ const defaultColors = [
 export const ColorPicker = ({
   onChange,
   colors,
+  defaultColor,
   bg,
   placement,
   isDisabled,
 }: ColorPickerProps) => {
   const [isOpen, setIsOpen] = useBoolean();
-  const [selectedColor, setSelectedColor] = useState<string>("");
   const colorPalette = colors || defaultColors;
+  const [selectedColor, setSelectedColor] = useState<string>(defaultColor || colorPalette[0]);
 
   return (
     <Popover
@@ -42,7 +43,7 @@ export const ColorPicker = ({
     >
       <PopoverTrigger>
         <Button
-          bg={selectedColor || "white"}
+          bg={selectedColor}
           onClick={setIsOpen.toggle}
           _hover={{ bg: selectedColor, transform: "scale(1.05)" }}
           _active={{ bg: selectedColor }}
@@ -79,6 +80,7 @@ export const ColorPicker = ({
 interface ColorPickerProps {
   onChange: (value: string) => void;
   colors?: string[];
+  defaultColor?: string;
   bg?: string;
   placement?: PlacementWithLogical;
   isDisabled?: boolean;


### PR DESCRIPTION
This component was defaulting to white, which is problematic because white may not be in the color palette.

These changes allow a new `defaultColor` property which sets the initial state of the component. When this property is not specified, the component will now default to the first color swatch.

An alternate solution would be to make this component fully-controlled, so that it accepts a `value` and `onChange` and has no internal state to store the currently selected color.